### PR TITLE
Tutorial refers to correct pip install paho-mqtt

### DIFF
--- a/tutorial.txt
+++ b/tutorial.txt
@@ -3,12 +3,12 @@ RPI: python tutorial
 1. copy raspian image to an sdcard
 2. expand file system & reboot
 3. run: sudo apt-get update     (to update all packages)
-4. prepare python, run:	
+4. prepare python, run:
 	sudo apt-get install python-dev
 	sudo apt-get install python-pip
 	sudo easy_install -U distribute
 	sudo pip install RPi.GPIO
-	sudo pip install paho.mqtt.client
+	sudo pip install paho-mqtt
 5. copy demo file to RPI
 6. make it executable, run:
 	chmod +x ATT_RPI_Demo.py


### PR DESCRIPTION
- The previous version yielded:

➜  raspberrypi-python-client git:(master) pip install paho.mqtt.client
Downloading/unpacking paho.mqtt.client
  Could not find any downloads that satisfy the requirement paho.mqtt.client
Cleaning up...
No distributions at all found for paho.mqtt.client
Storing debug log for failure in /Users/peter_v/.pip/pip.log

with log file:
## ➜  raspberrypi-python-client git:(master) cat ~/.pip/pip.log

/usr/local/bin/pip run on Thu Dec  4 19:05:08 2014
Downloading/unpacking paho.mqtt.client
  Getting page https://pypi.python.org/simple/paho.mqtt.client/
  Could not fetch URL https://pypi.python.org/simple/paho.mqtt.client/: 404 Client Error: Not Found
  Will skip URL https://pypi.python.org/simple/paho.mqtt.client/ when looking for download links for paho.mqtt.client
  Getting page https://pypi.python.org/simple/
  URLs to search for versions for paho.mqtt.client:
- https://pypi.python.org/simple/paho.mqtt.client/
  Getting page https://pypi.python.org/simple/paho.mqtt.client/
  Could not fetch URL https://pypi.python.org/simple/paho.mqtt.client/: 404 Client Error: Not Found
  Will skip URL https://pypi.python.org/simple/paho.mqtt.client/ when looking for download links for paho.mqtt.client
  Could not find any downloads that satisfy the requirement paho.mqtt.client
  Cleaning up...
  Removing temporary dir /private/var/folders/1q/3_rsfwqd4b93sj7m6rnbzj8h0000gn/T/pip_build_peter_v...
  No distributions at all found for paho.mqtt.client
  Exception information:
  Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.8_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pip-1.5.6-py2.7.egg/pip/basecommand.py", line 122, in main
    status = self.run(options, args)
  File "/usr/local/Cellar/python/2.7.8_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pip-1.5.6-py2.7.egg/pip/commands/install.py", line 278, in run
    requirement_set.prepare_files(finder, force_root_egg_info=self.bundle, bundle=self.bundle)
  File "/usr/local/Cellar/python/2.7.8_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pip-1.5.6-py2.7.egg/pip/req.py", line 1177, in prepare_files
    url = finder.find_requirement(req_to_install, upgrade=self.upgrade)
  File "/usr/local/Cellar/python/2.7.8_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pip-1.5.6-py2.7.egg/pip/index.py", line 277, in find_requirement
    raise DistributionNotFound('No distributions at all found for %s' % req)
  DistributionNotFound: No distributions at all found for paho.mqtt.client
